### PR TITLE
PR 21: Suppress planner schedules for non-schedule meds flows

### DIFF
--- a/services/api/tests/unit/test_nodes.py
+++ b/services/api/tests/unit/test_nodes.py
@@ -51,24 +51,40 @@ def test_health_node_with_med_terms():
     assert len(new_state["citations"]) == 2
 
 
-def test_planner_node_meds_intent():
-    state: BodyState = {"user_query": "", "user_query_redacted": "", "intent": "meds"}
+def test_planner_node_meds_schedule_intent():
+    state: BodyState = {
+        "user_query": "",
+        "user_query_redacted": "",
+        "intent": planner.MEDS_INTENT,
+        "sub_intent": planner.SUB_INTENT_SCHEDULE,
+    }
     new_state = planner.run(state)
-    assert new_state["plan"]["type"] == "med_schedule"
+    assert new_state["plan"]["type"] == planner.PLAN_TYPE_MED_SCHEDULE
+
+
+def test_planner_node_meds_non_schedule():
+    state: BodyState = {
+        "user_query": "",
+        "user_query_redacted": "",
+        "intent": planner.MEDS_INTENT,
+        "sub_intent": "onset",
+    }
+    new_state = planner.run(state)
+    assert new_state["plan"] == {"type": planner.PLAN_TYPE_NONE}
 
 
 def test_planner_node_appointment_intent():
     state: BodyState = {
         "user_query": "",
         "user_query_redacted": "",
-        "intent": "appointment",
+        "intent": planner.APPOINTMENT_INTENT,
         "candidates": [
             {"name": "Clinic A", "phone": "123", "kind": "clinic"},
             {"name": "Clinic B", "phone": "456", "kind": "lab"},
         ],
     }
     new_state = planner.run(state)
-    assert new_state["plan"]["type"] == "appointment"
+    assert new_state["plan"]["type"] == planner.APPOINTMENT_INTENT
     assert new_state["plan"]["provider"]["name"] == "Clinic A"
 
 

--- a/services/api/tests/unit/test_planner.py
+++ b/services/api/tests/unit/test_planner.py
@@ -3,12 +3,13 @@ from app.graph.state import BodyState
 from datetime import datetime, UTC
 
 
-def test_planner_meds_intent():
-    """Test that the planner creates a med schedule for the 'meds' intent."""
+def test_planner_meds_schedule_sub_intent():
+    """Planner keeps schedule only when meds sub_intent is 'schedule'."""
     state = BodyState(
         user_id="test-user",
         user_query="schedule my meds",
-        intent="meds",
+        intent=planner.MEDS_INTENT,
+        sub_intent=planner.SUB_INTENT_SCHEDULE,
     )
 
     # We don't need a real ES client for this test
@@ -18,7 +19,7 @@ def test_planner_meds_intent():
 
     assert "plan" in new_state
     plan = new_state["plan"]
-    assert plan["type"] == "med_schedule"
+    assert plan["type"] == planner.PLAN_TYPE_MED_SCHEDULE
     assert len(plan["items"]) == 2
 
     now = datetime.now(UTC)
@@ -29,3 +30,15 @@ def test_planner_meds_intent():
     item2 = plan["items"][1]
     assert item2["title"] == "Evening meds"
     assert datetime.fromisoformat(item2["time"]) > datetime.fromisoformat(item1["time"])
+
+
+def test_planner_meds_non_schedule_gets_none_plan():
+    state = BodyState(
+        intent=planner.MEDS_INTENT,
+        sub_intent="onset",
+        user_query="when does it work",
+    )
+
+    new_state = planner.run(state)
+
+    assert new_state["plan"] == {"type": planner.PLAN_TYPE_NONE}


### PR DESCRIPTION
## Outcome
Planner no longer emits medication schedules when the meds sub_intent is not `schedule`, so onset questions skip auto-planning.

## Demo
```bash
venv/bin/pytest services/api/tests/unit/test_planner.py::test_planner_meds_non_schedule_gets_none_plan
```

## Acceptance
- [x] Tests: venv/bin/pytest
- [x] Docs: N/A
- [ ] Not demoable:
