### PR TITLE
Improve meds interaction recall and language-aware answers

### DIFF
--- a/project/roadmap/pr-stack.md
+++ b/project/roadmap/pr-stack.md
@@ -159,37 +159,22 @@ Acceptance
 
 # Milestone 2 — Retrieval quality & cleanliness
 
-## PR 24 — Health BM25 fallback with med boosts
+## PR 24–26 — Med interaction recall, citation hygiene, language-aware answers
 
-Why: When kNN misses, ensure BM25 still surfaces interaction docs tied to the user’s meds.
+Why: Ensure meds interactions surface even when kNN misses, clean up citation spam, and keep deterministic/template answers aligned with the user’s language.
 
 Scope
 
-- In BM25 fallback, include boosted `match` clauses for each med’s title/text plus the primary query/pivot; keep `minimum_should_match = 1`.
-- Add integration coverage for the dual-med interaction flow.
+- BM25 fallback adds boosted clauses for each memory med combined with the primary/pivot query so interaction docs still appear when embeddings miss.
+- Normalize/dedupe citations (`url_normalize` strips fragments + UTM params) to avoid duplicate or noisy links.
+- `answer_gen` system prompts/templates explicitly follow `state.language` (fallback EN) so Hebrew users get Hebrew output end-to-end.
+- Expand unit/integration coverage for the dual-med interaction flow, citation hygiene, and language-aware prompts.
 
 Acceptance
 
-- Interaction documents retrieved when user memory has two interacting meds.
-- `tests/integration/test_api_integration.py::test_e2e_medication_interaction_flow` updated.
-
-## PR 25 — Citation dedupe & URL normalization
-
-Why: Avoid duplicate citations when docs arrive via registry + search.
-
-Scope
-
-- Introduce `url_normalize` (strip fragments + UTM params) and dedupe citations while preserving order.
-- Unit tests for normalization + dedupe behaviour.
-
-## PR 26 — Language-aware answer rendering
-
-Why: Answers should default to the user’s language, not always English.
-
-Scope
-
-- `answer_gen` chooses templates/prompts using `state.language` (fallback EN).
-- Tests ensure HE queries yield HE answers while EN remains unchanged.
+- Interaction documents retrieved whenever memory contains both meds; integration test validates boosted combo clauses.
+- Citations emitted without fragments/`utm_` tracking params and remain unique while preserving order.
+- Hebrew answer paths (LLM fallback + deterministic meds onset) render in Hebrew; English flows unchanged.
 
 ## PR 32 — Paraphrase onset facts via Ollama (flagged)
 


### PR DESCRIPTION
## Outcome
Surface medication-interaction guidance even when embeddings miss, keep citations clean, and ensure answer generation mirrors the user’s language.

## Demo
```bash
# Requires API stack running locally
curl -s http://localhost:8000/api/graph/run \
  -H 'content-type: application/json' \
  -d '{"user_id":"demo","query":"אקמול מתי משפיע?"}' \
  | jq '.state | {language, citations, reply: .messages[-1].content}'

curl -s http://localhost:8000/api/graph/run \
  -H 'content-type: application/json' \
  -d '{"user_id":"med-interact","query":"What are the interactions between Ibuprofen and Warfarin?"}' \
  | jq '.state | {alerts, citations}'
```
_(Expect Hebrew reply with NHS citation in the first command; the second surfaces interaction alerts with deduplicated, tracking-free citations.)_

## Acceptance checks
- [x] **Unit / integration**: `services/api/tests/unit/test_health.py`, `services/api/tests/unit/test_answer_gen.py`, `services/api/tests/integration/test_api_integration.py::test_e2e_medication_interaction_flow`
- [x] **i18n / locale**: Verified Hebrew prompts carry through `_generate_with_provider` and Hebrew deterministic onset answers.
- [x] **Observability**: BM25 handler assertions ensure combined med+query clauses hit fake ES; debug output shows normalized citations.
- [x] **Safety / disclaimers**: Answer generation still appends standard disclaimers/urgent lines and skips LLM for deterministic onset.

## Scope
**Included**
- BM25 fallback boosts per-medication combo clauses when kNN misses.
- Citation normalization/deduplication with fragment and `utm_*` stripping.
- Language-aware system prompts for LLM providers.
- Updated unit/integration coverage and roadmap entry merge.

**Excluded**
- Additional meds facts content beyond existing seeds.
- Telemetry counters for citation normalization hits/misses.
- Paraphrasing or LLM fallback for missing onset facts (deferred to PR 32/33).

## Data & provenance
No changes to persisted datasets; med facts remain in `seeds/med_facts.json`.

## Rollback / Flags
Revert this PR or deploy previous image; no new feature flags involved.

## Risks / Mitigations
- **Over-broad boosts** → Limited to user meds + primary query; tests guard interaction cases.
- **Citation stripping edge cases** → Unit tests cover non-string, custom schemes, and parsing failures.
- **Language regressions** → Hebrew integration test exercises the fallback path.

## Docs & follow-up
- Roadmap updated (`project/roadmap/pr-stack.md`).
- Follow-up: add telemetry for med fact misses (tracked separately).
