### PR TITLE
feat: add optional meds onset paraphrase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ RISK_ONSET_RED_FLAGS=chest pain,chest pains,bleed,bleeding,hemorrhage,hemorrhagi
 
 # Deterministic medication facts registry
 MED_FACTS_PATH=/app/seeds/med_facts.json
+PARAPHRASE_ONSET=false
 
 # Intent routing (embedding exemplars)
 INTENT_EXEMPLARS_PATH=/app/data/intent_exemplars.jsonl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Scope: These instructions apply to the whole repository. They are for AI coding 
 - `services/api/app/graph/nodes/` — pipeline nodes (supervisor, scrub, memory, health, risk_ml, places, planner, answer_gen, critic).
 - `services/api/app/graph/build.py` — LangGraph wiring and routing.
 - `services/api/app/tools/` — shared utilities (embeddings, ES client, crypto, language, etc.).
-- `project/` — product docs: roadmap (`project/roadmap.md`, `project/roadmap/pr-stack.md`, `project/roadmap/ideas.md`), direction (`project/vision.md`, `project/architecture.md`), and runbooks (`project/config.md`, `project/evaluation.md`, `project/privacy.md`, `project/troubleshooting.md`).
+- `project/` — product docs: roadmap (`project/roadmap.md`, `project/roadmap/pr-stack.md`, `project/roadmap/shipped.md`, `project/roadmap/ideas.md`), direction (`project/vision.md`, `project/architecture.md`), and runbooks (`project/config.md`, `project/evaluation.md`, `project/privacy.md`, `project/troubleshooting.md`).
 - `seeds/` — seed KB and providers. E2E tests rely on this content.
 - `docker-compose.yml` — local dev stack; note mounted volumes.
 
@@ -83,7 +83,7 @@ Scope: These instructions apply to the whole repository. They are for AI coding 
 - Otherwise:
   - Propose an entry under “Scheduled” in `project/roadmap/ideas.md`.
   - If ready to execute, add a new PR block in `project/roadmap/pr-stack.md` with Why/Scope/Acceptance/Pointers.
-- When a PR is finished, remove its block from `project/roadmap/pr-stack.md` and mark the corresponding idea as completed in `project/roadmap/ideas.md`.
+- When a PR is finished, remove its block from `project/roadmap/pr-stack.md`, add a short summary to `project/roadmap/shipped.md`, and mark the corresponding idea as completed in `project/roadmap/ideas.md`.
 
 ## Communication (for agents)
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ When stubbing is active, the risk classification will return deterministic, defa
 
 To tweak the meds-onset gating, set `RISK_ONSET_RED_FLAGS` to a comma-separated list of phrases, listing each variant you care about (e.g., `RISK_ONSET_RED_FLAGS=chest pain,chest pains,bleed,bleeding`). Any query containing one of the phrases will always run through the ML risk model instead of being suppressed.
 
+Deterministic onset answers can be lightly localized by enabling `PARAPHRASE_ONSET=true` (defaults to `false`). When enabled, the node calls the configured Ollama model to rewrite the fact copy while preserving every numeric value; if validation fails or Ollama is unreachable, the canonical wording is used.
+
 
 ### Security & Tenancy (PR 8)
 

--- a/project/config.md
+++ b/project/config.md
@@ -49,6 +49,11 @@ This page lists the key environment variables, defaults, and how to run in CI (s
 - `FALLBACK_TEMPLATES_PATH` (optional; default unset; example `/app/data/safety_templates.json`)
 - `FALLBACK_TEMPLATES_WATCH` (`true|false`)
 
+## Deterministic meds onset
+
+- `MED_FACTS_PATH` (default `/app/seeds/med_facts.json`)
+- `PARAPHRASE_ONSET` (`true|false`, default `false`; paraphrase deterministic onset copy via Ollama with numeric validation)
+
 ## Modes
 
 ### CI mode (deterministic)

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -1,25 +1,20 @@
 # Roadmap (MVP → v1)
 
-## Now — Milestone 1 (Meds “onset” relevance)
+## Now — Milestone 2 (Optional meds onset polish)
 
-- Language detection + HE→EN pivot for retrieval (PR 18)
-- Med normalization lexicon + sub-intent classification (PR 19–20)
-- Planner/risk gating updates for onset flows (PR 21–22)
-- Deterministic med-facts micro-KB powering onset answers (PR 23)
+- Paraphrase deterministic onset facts without changing numbers (PR 25, flagged)
+- Neutral LLM fallback when no onset fact exists (PR 26, flagged)
 
-## Next — Milestone 2 (Retrieval quality & cleanliness)
+## Next — Milestone 3 (Stability & CI polish)
 
-- BM25 fallback with medication boosts when kNN misses (PR 24)
-- Citation dedupe with URL normalization (PR 25)
-- Language-aware answer rendering in `answer_gen` (PR 26)
-- Optional, safe LLM polish behind flags:
-  - Paraphrase deterministic onset facts (no new numbers) via Ollama (PR 32)
-  - Neutral LLM fallback when no onset fact exists (no timings/doses) (PR 33)
+- Idempotent seed job for ingest scripts (PR 27)
+- SSE contract regression test (PR 28)
+- Docs roll-up linking architecture/config/evaluation references (PR 29)
 
-## Later — Milestones 3 & 4 (Stability + privacy)
+## Later — Milestone 4 (Intent + privacy hardening)
 
-- Idempotent seed job, SSE contract test, docs polish (PR 27–29)
-- Intent exemplar hot-reload refinements + expanded PII scrub rules (PR 30–31)
+- Intent exemplar hot-reload refinements (PR 30)
+- Expanded PII scrub rules for gov IDs and addresses (PR 31)
 -- Longer-term: client-side field encryption, calendar integration, vetted MCP adapters
 
-See `project/roadmap/pr-stack.md` for current PR slices and acceptance criteria.
+See `project/roadmap/pr-stack.md` for current PR slices and acceptance criteria. Completed work is archived in `project/roadmap/shipped.md`.

--- a/project/roadmap/ideas.md
+++ b/project/roadmap/ideas.md
@@ -19,18 +19,21 @@ Use the status column to see whether an idea is already shipped, queued up in th
 | ✅ | Pattern-based fallback templates | Provide localized symptom templates when retrieval is empty; include disclaimers and risk notices. | Shipped in PR 15; templates now keep safety messaging when providers fail. |
 | ✅ | Retrieval expansion | Synonym/translation boosts and section boosting for health retrieval (e.g., "כאבי בטן" → "abdominal pain"). | Shipped in PR 14; tuned boosts while respecting doc language. |
 | ✅ | Structured symptom registry | Map symptom slugs → vetted doc refs and language variants; inject before ES search. | Shipped in PR 16; deduping preserves localized snippets. |
+| ✅ | Docs & roadmap refresh | Added architecture/config/privacy/evaluation docs and aligned README streaming guidance. | Shipped in PR 17; terminology stays consistent across guides. |
+| ✅ | Language detect & EN pivot | Detect Hebrew queries and expose `user_query_pivot` so downstream retrieval stays stable. | Shipped in PR 18; health/risk nodes reuse the pivot text. |
+| ✅ | Med normalization | Normalize common brands → ingredients during ingest and supervisor flows. | Shipped in PR 19; table-driven alias coverage. |
+| ✅ | Meds sub-intent classification | Classify meds queries into onset/interaction/schedule/etc. for deterministic routing. | Shipped in PR 20; bilingual keyword rules + tests. |
+| ✅ | Planner suppression for meds | Skip schedule plans unless `sub_intent == "schedule"`. | Shipped in PR 21; planner tests assert gating. |
+| ✅ | Risk gating for meds onset | Relax risk thresholds for benign onset questions while keeping red-flag escalations. | Shipped in PR 22; parametrized risk tests. |
+| ✅ | Deterministic meds onset answers | Serve onset guidance from vetted facts with localized copy and single citation. | Shipped in PR 23; med_facts helper + integration coverage. |
+| ✅ | Med interaction recall & language-aware answers | Boost BM25 combos, dedupe citations, and follow `state.language` in answers. | Shipped in PR 24; interaction flow integration updated. |
 
 ## Scheduled (see `pr-stack.md`)
 
 | Status | Idea | Summary | Notes |
 | --- | --- | --- | --- |
-| 🔄 | KB seeding & translation pipeline | Extend ingestion scripts to seed HE symptom guidance so fallback rarely fires. | Current PR 17. See project/roadmap/pr-stack.md. |
-| 🔄 | Language detect & EN pivot | Detect HE and pivot query text to EN for stable retrieval; thread `user_query_pivot`. | Planned as PR 18. See pr-stack. |
-| 🔄 | Med normalization | Minimal lexicon to normalize brands → ingredients; enrich memory facts. | Planned as PR 19. See pr-stack. |
-| 🔄 | Meds sub-intent | Classify meds sub-intent (onset, interaction, schedule, etc.) for flow gating. | Planned as PR 20. See pr-stack. |
-| 🔄 | Planner suppression (meds) | Do not emit schedule for meds flows unless sub-intent is `schedule`. | Planned as PR 21. See pr-stack. |
-| 🔄 | Risk gating for onset | Raise thresholds/short-circuit risk for benign meds onset flows. | Planned as PR 22. See pr-stack. |
-| 🔄 | Med facts micro-KB | Deterministic onset metadata and citations for common meds; render localized answers. | Planned as PR 23. See pr-stack. |
+| 🔄 | Paraphrase onset facts (flagged) | Optional Ollama paraphrase for deterministic onset answers; no new numbers. | Planned as PR 25. See pr-stack. |
+| 🔄 | Neutral onset fallback (flagged) | Safe LLM blurb when no med fact exists (no timings/doses). | Planned as PR 26. See pr-stack. |
 
 ## Backlog / To Evaluate
 
@@ -71,8 +74,7 @@ Use the status column to see whether an idea is already shipped, queued up in th
 | --- | --- | --- | --- |
 | 🧭 | Preference-aware provider scoring | Blend semantic score with distance, hours fit, insurance match using configurable weights. | Requires more provider metadata + tests. |
 | 🧭 | Lightweight meds registry | Small YAML of common OTC classes (uses, avoid_if, interactions) to supplement answers without dosing. | Consider after Milestone 2; overlap with med facts work. |
-| 🧭 | LLM paraphrase for onset facts | When a deterministic med fact exists, paraphrase it into the user’s language via Ollama (no new numbers/claims) behind a feature flag. | Enforce validators to reject added numbers; always include “Source: …”. |
-| 🧭 | LLM neutral fallback (no fact) | If no onset fact is found, generate a neutral, non‑timed guidance blurb (no dosing/times) behind a feature flag. | Safer than guessing; reject outputs with numbers/time words; include disclaimer.
+| 🧭 | KB seeding & translation pipeline | Extend ingestion scripts to translate vetted symptom docs into Hebrew and store provenance. | Requires `scripts/ingest_public_kb.py` updates + seeding automation. |
 
 When you pick up an idea:
 

--- a/project/roadmap/shipped.md
+++ b/project/roadmap/shipped.md
@@ -1,0 +1,70 @@
+# Shipped PR Log
+
+Chronicles of recently completed work. Each entry mirrors the acceptance criteria that were previously tracked in `pr-stack.md`.
+
+## PR 24 — Improve meds interaction recall and language-aware answers
+
+- Boosted BM25 fallback with combined medication clauses so interaction docs surface even when embeddings miss.
+- Normalized and deduped citations (stripping fragments/`utm_*`) to keep the answer footer clean and stable.
+- Threaded `state.language` through answer generation so Hebrew users see localized deterministic + LLM responses; expanded interaction integration coverage.
+
+## PR 23 — Deterministic meds onset answers
+
+- Added `services/api/app/tools/med_facts.py` and seeded `seeds/med_facts.json` with vetted onset windows for acetaminophen/ibuprofen.
+- Answer generator now assembles meds-onset replies directly from facts (per language) with exactly one citation and no planner/risk overrides.
+- Unit + integration tests cover fact loading, language selection, and Hebrew onset flows.
+
+## PR 22 — Risk gating for meds onset
+
+- Updated `services/api/app/graph/nodes/risk_ml.py` to short-circuit benign meds-onset queries while preserving hard red-flag alerts.
+- Tuned thresholds/heuristics so chest-pain and bleeding terms still trigger ML escalation.
+- Added parametrized coverage in `services/api/tests/unit/test_risk_and_critic.py`.
+
+## PR 21 — Planner suppression for non-schedule meds flows
+
+- Planner now forces `plan = {"type": "none"}` when `intent == "meds"` and `sub_intent` is not `schedule`.
+- Logged suppression decisions for observability and extended planner tests to assert the gating logic.
+
+## PR 20 — Meds sub-intent routing
+
+- Supervisor derives `state["sub_intent"]` via bilingual keyword rules, covering onset, interaction, schedule, side_effects, and refill buckets.
+- Persisted sub-intent in graph state so planner/risk/answer nodes can branch deterministically.
+- Expanded `services/api/tests/unit/test_supervisor.py` + supervisor/planner combo tests for EN/HE phrases.
+
+## PR 19 — Med normalization (brand → ingredient)
+
+- Introduced `services/api/app/tools/med_normalize.py` with multilingual alias → ingredient mapping and helpers to find meds in text.
+- Memory ingest + supervisor normalize detected meds, storing `normalized.ingredient` for consistent comparisons.
+- Table-driven coverage in `services/api/tests/unit/test_med_normalize.py` and helper unit tests.
+
+## PR 18 — Language detect & pivot to EN for retrieval
+
+- `scrub` node now tracks `state["language"]` and sets `state["user_query_pivot"]` for non-English inputs.
+- Health/risk nodes consume the pivot text for retrieval while preserving the original query for messaging.
+- Added HE/EN detection tests in `services/api/tests/unit/test_scrub.py` and integration assertions.
+
+## PR 17 — Review follow-up (docs + copy tweaks)
+
+- Architecture, config, privacy, evaluation, troubleshooting, and roadmap docs landed under `project/` with aligned terminology.
+- README streaming example uses `curl --no-buffer`, highlights intent exemplar hot-reload, and notes the `{ "state": ... }` envelope.
+- Template fallback keeps risk notices when only pattern templates fire (PR 15 polish).
+
+## PR 16 — Structured symptom registry (doc routing)
+
+- Added `services/api/app/registry/symptoms.yml` with canonical symptom phrases, risk flags, and doc references.
+- Introduced loader `app/tools/symptom_registry.py` (cached, env override) and wired `health.run` to inject registry docs ahead of ES search.
+- Ensured registry docs dedupe with kNN/BM25 results while preserving language prioritization.
+- Seeded abdominal-pain markdown and unit tests verifying registry lookups and ordering.
+
+## PR 15 — Pattern-based fallback (safety templates)
+
+- Added symptom-bucket templates (GI, respiratory, neuro, general) with EN/HE copies to cover no-retrieval cases.
+- Template fallback now mirrors recap format: summary, template body, and risk notices before disclaimer/urgent lines.
+- Tests cover GI fallback, Hebrew variants, YAML overrides, and risk notice preservation when providers fail.
+
+## PR 14 — Retrieval expansion (query expansion + scoring)
+
+- `health.run` now expands symptom queries via the registry, appending EN synonyms/HE variants before embedding.
+- BM25 fallback includes boosted `section:general|warnings` matches and still respects medication-derived terms.
+- Added targeted unit coverage for Hebrew stomach-pain flows, ensuring abdominal-pain snippets rise to the top.
+- Updated seeds/tests so abdominal-pain guidance is consistently surfaced when available.

--- a/services/api/app/graph/nodes/answer_gen.py
+++ b/services/api/app/graph/nodes/answer_gen.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from app.config import settings
@@ -314,8 +315,14 @@ def _meds_onset_message(state: BodyState) -> Optional[Tuple[str, List[str]]]:
         if not fact:
             continue
 
-        lines = [fact["summary"]]
+        summary = fact["summary"]
         follow_up = fact.get("follow_up")
+
+        paraphrased = _paraphrase_onset_fact(fact, lang)
+        if paraphrased:
+            summary, follow_up = paraphrased
+
+        lines = [summary]
         if follow_up:
             lines.append(follow_up)
         source_label = str(fact.get("source_label", "")).strip()
@@ -535,3 +542,101 @@ def run(state: BodyState) -> BodyState:
     }
     state.setdefault("messages", []).append(message)
     return state
+
+
+def _paraphrase_enabled() -> bool:
+    return os.getenv("PARAPHRASE_ONSET", "false").strip().lower() == "true"
+
+
+_JSON_FENCE_PATTERN = re.compile(r"```(?:json)?(.*?)```", re.DOTALL | re.IGNORECASE)
+
+
+def _strip_code_fence(text: str) -> str:
+    match = _JSON_FENCE_PATTERN.search(text)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _parse_json_object(text: str) -> Optional[dict]:
+    candidate = _strip_code_fence(text)
+    try:
+        return json.loads(candidate)
+    except json.JSONDecodeError:
+        pass
+    brace_match = re.search(r"\{.*\}", candidate, re.DOTALL)
+    if brace_match:
+        snippet = brace_match.group(0)
+        try:
+            return json.loads(snippet)
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+_NUMERIC_PATTERN = re.compile(r"\d+(?:[.,]\d+)?")
+
+
+def _numeric_tokens(*texts: str) -> set[str]:
+    tokens: set[str] = set()
+    for text in texts:
+        for match in _NUMERIC_PATTERN.findall(text or ""):
+            tokens.add(match)
+    return tokens
+
+
+def _paraphrase_onset_fact(
+    fact: Dict[str, Any], language: str
+) -> Optional[Tuple[str, Optional[str]]]:
+    if not _paraphrase_enabled():
+        return None
+
+    summary = str(fact.get("summary", "")).strip()
+    follow_up = str(fact.get("follow_up", "")).strip()
+    if not summary:
+        return None
+
+    original_numbers = _numeric_tokens(summary, follow_up)
+
+    prompt = (
+        "You paraphrase medication onset guidance without changing factual meaning.\n"
+        "Language: {language}.\n"
+        "Rules:\n"
+        "- Preserve every numeric value exactly as provided.\n"
+        "- Do not invent new claims, times, or dosages.\n"
+        '- Respond with valid JSON: {{"summary": <text>, "follow_up": <text>}}.\n'
+        "- Keep follow_up empty string if none supplied.\n"
+        "Original summary: {summary}\n"
+        "Original follow_up: {follow_up}"
+    ).format(language=language, summary=summary, follow_up=follow_up or "<none>")
+
+    rewritten = _call_ollama(prompt, language)
+    if not rewritten:
+        return None
+
+    data = _parse_json_object(rewritten)
+    if not isinstance(data, dict):
+        logger.warning("Paraphrase response was not valid JSON")
+        return None
+
+    new_summary = str(data.get("summary", "")).strip()
+    new_follow_up = str(data.get("follow_up", "")).strip()
+
+    if not new_summary:
+        logger.warning("Paraphrase missing summary text")
+        return None
+
+    new_numbers = _numeric_tokens(new_summary, new_follow_up)
+    if original_numbers and new_numbers != original_numbers:
+        logger.warning(
+            "Paraphrase introduced or dropped numeric values: original=%s new=%s",
+            sorted(original_numbers),
+            sorted(new_numbers),
+        )
+        return None
+
+    if not original_numbers and new_numbers:
+        logger.warning("Paraphrase unexpectedly introduced numeric values")
+        return None
+
+    return new_summary, (new_follow_up or None)

--- a/services/api/tests/unit/test_answer_gen.py
+++ b/services/api/tests/unit/test_answer_gen.py
@@ -1,6 +1,7 @@
 import os
 import builtins
 import sys
+import json
 
 import pytest
 
@@ -47,6 +48,175 @@ def test_answer_gen_meds_onset_uses_med_facts(monkeypatch):
     citations = out.get("citations", [])
     assert len(citations) == 1
     assert citations[0].startswith("https://")
+
+
+def test_answer_gen_meds_onset_paraphrases_when_enabled(monkeypatch):
+    med_facts.clear_cache()
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    def fake_call(prompt: str, language: str):
+        assert "JSON" in prompt
+        payload = {
+            "summary": "אקמול מתחיל להקל לרוב בתוך 30–60 דקות.",
+            "follow_up": "עקבו אחר ההרגשה; אם אין שיפור תוך כשעה, פנו לרופא.",
+        }
+        return json.dumps(payload)
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", fake_call)
+
+    state = BodyState(
+        user_query="אקמול מתי משפיע",
+        user_query_redacted="אקמול מתי משפיע",
+        intent="meds",
+        sub_intent="onset",
+        language="he",
+        debug={"normalized_query_meds": ["acetaminophen"]},
+        messages=[],
+    )
+
+    out = answer_gen.run(state)
+    content = out["messages"][-1]["content"]
+
+    assert "עקבו אחר ההרגשה" in content
+    assert "30" in content
+    assert "Source: NHS" in content
+    assert answer_gen.LANG_CONFIG["he"]["disclaimer"] in content
+
+
+def test_answer_gen_meds_onset_paraphrase_rejects_new_numbers(monkeypatch):
+    med_facts.clear_cache()
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+    monkeypatch.setenv("LLM_PROVIDER", "ollama")
+
+    def bad_call(prompt: str, language: str):
+        payload = {
+            "summary": "אקמול מתחיל לפעול אחרי 45 דקות בדיוק.",
+            "follow_up": "אם אין שיפור תוך שעתיים, פנו לרופא.",
+        }
+        return json.dumps(payload)
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", bad_call)
+
+    state = BodyState(
+        user_query="אקמול מתי משפיע",
+        user_query_redacted="אקמול מתי משפיע",
+        intent="meds",
+        sub_intent="onset",
+        language="he",
+        debug={"normalized_query_meds": ["acetaminophen"]},
+        messages=[],
+    )
+
+    out = answer_gen.run(state)
+    content = out["messages"][-1]["content"]
+
+    # Falls back to canonical wording when validation fails
+    assert "45" not in content
+    assert "אקמול בדרך כלל" in content
+
+
+def test_paraphrase_helper_handles_code_fence(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    def fenced_call(prompt: str, language: str):
+        return '```json\n{"summary": "איבופרופן מפחית כאב תוך 20–30 דקות.", "follow_up": ""}\n```'
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", fenced_call)
+    fact = {
+        "summary": "איבופרופן לרוב מתחיל להקל על כאב או חום תוך 20–30 דקות מהנטילה.",
+        "follow_up": "",
+    }
+
+    summary, follow_up = answer_gen._paraphrase_onset_fact(fact, "he")
+    assert "20" in summary and "30" in summary
+    assert follow_up is None
+
+
+def test_paraphrase_helper_rejects_invalid_json(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", lambda prompt, language: "not-json")
+
+    fact = {
+        "summary": "אקמול בדרך כלל מתחיל להשפיע תוך 30–60 דקות.",
+        "follow_up": "אם אין שיפור תוך כשעה, פנו לרופא.",
+    }
+
+    assert answer_gen._paraphrase_onset_fact(fact, "he") is None
+
+
+def test_paraphrase_helper_blocks_new_numbers_when_none_present(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    def introduce_number(prompt: str, language: str):
+        return json.dumps({"summary": "התרופה פועלת תוך 5 דקות.", "follow_up": ""})
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", introduce_number)
+
+    fact = {"summary": "התרופה פועלת במהירות.", "follow_up": ""}
+
+    assert answer_gen._paraphrase_onset_fact(fact, "he") is None
+
+
+def test_paraphrase_helper_parses_embedded_json(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    def embedded(prompt: str, language: str):
+        return 'prefix {"summary": "Ibuprofen eases symptoms within 20–30 minutes.", "follow_up": "Follow up if symptoms persist."} suffix'
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", embedded)
+
+    fact = {
+        "summary": "Ibuprofen usually begins easing pain or fever within 20–30 minutes after a dose.",
+        "follow_up": "If there is no improvement after about an hour or symptoms worsen, speak with a clinician.",
+    }
+
+    summary, follow_up = answer_gen._paraphrase_onset_fact(fact, "en")
+    assert "20" in summary and "30" in summary
+    assert "Follow up" in follow_up
+
+
+def test_paraphrase_helper_handles_invalid_embedded_json(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    def invalid(prompt: str, language: str):
+        return 'prefix {"summary": } suffix'
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", invalid)
+
+    fact = {
+        "summary": "Ibuprofen usually begins easing pain or fever within 20–30 minutes after a dose.",
+        "follow_up": "If there is no improvement after about an hour or symptoms worsen, speak with a clinician.",
+    }
+
+    assert answer_gen._paraphrase_onset_fact(fact, "en") is None
+
+
+def test_paraphrase_helper_requires_summary(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    def fail(prompt: str, language: str):  # pragma: no cover
+        raise AssertionError("_call_ollama should not run when summary missing")
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", fail)
+
+    fact = {"summary": "", "follow_up": ""}
+
+    assert answer_gen._paraphrase_onset_fact(fact, "he") is None
+
+
+def test_paraphrase_helper_returns_none_when_call_fails(monkeypatch):
+    monkeypatch.setenv("PARAPHRASE_ONSET", "true")
+
+    monkeypatch.setattr(answer_gen, "_call_ollama", lambda prompt, language: None)
+
+    fact = {
+        "summary": "אקמול בדרך כלל מתחיל להשפיע תוך 30–60 דקות.",
+        "follow_up": "אם אין שיפור תוך כשעה, פנו לרופא.",
+    }
+
+    assert answer_gen._paraphrase_onset_fact(fact, "he") is None
 
 
 def test_answer_gen_meds_onset_falls_back_to_english(monkeypatch):


### PR DESCRIPTION
## Outcome
Optional meds-onset answers can now use Ollama to paraphrase the deterministic fact copy without changing any numbers, keeping localized guidance readable while staying fully citeable.

## Demo
```bash
# run focussed unit suite (uses stubbed Ollama responses)
PARAPHRASE_ONSET=true venv/bin/pytest services/api/tests/unit/test_answer_gen.py -k paraphrase
```

## Acceptance checks
- [x] **Unit / integration**: `venv/bin/pytest`
- [x] **i18n / locale**: Verified HE/EN paraphrase cases keep language-specific copy via unit tests.
- [x] **Observability**: Confirmed paraphrased paths continue to emit the deterministic citation + disclaimer through unit assertions.
- [x] **Safety / disclaimers**: Tests assert disclaimers/urgent messaging remain appended and numeric values are unchanged.

## Scope
**Included**
- Added the `PARAPHRASE_ONSET` flag with Ollama JSON paraphrasing + numeric validation in `answer_gen`.
- Wrote comprehensive paraphrase success/failure tests covering code-fence parsing and numeric guards.
- Documented the new flag in `.env.example`, README, and config docs; captured shipped work in `project/roadmap/shipped.md`.

**Excluded**
- No paraphrase support for other deterministic answers or OpenAI providers.
- Did not add telemetry around paraphrase usage or cache results.

## Data & provenance
No new datasets added; deterministic med facts remain in `seeds/med_facts.json`.

## Rollback / Flags
Set `PARAPHRASE_ONSET=false` (default) or revert commit `a9dfbed` to disable the paraphrase flow.

## Risks / Mitigations
- Ollama unavailability → gracefully falls back to canonical fact wording.
- LLM output drift → numeric/value validator rejects any changes, reverting to deterministic copy.

## Docs & follow-up
- Updated `.env.example`, `README.md`, and `project/config.md`.
- Follow-up: consider telemetry for paraphrase adoption (tracked separately).
