### PR TITLE
feat: make seed ingestion idempotent

### DIFF
--- a/scripts/ingest_providers.py
+++ b/scripts/ingest_providers.py
@@ -3,7 +3,7 @@ import logging
 import json
 import re
 import hashlib
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, helpers
 from sentence_transformers import SentenceTransformer
 from app.config import settings
 
@@ -35,18 +35,30 @@ def embed_one(text: str) -> list[float]:
 with open("seeds/providers/tel_aviv_providers.json", "r", encoding="utf-8") as f:
     data = json.load(f)
 
-logging.info(f"Indexing {len(data)} providers into {INDEX} using model {MODEL}.")
+logging.info("Indexing %d providers into %s using model %s.", len(data), INDEX, MODEL)
+
+actions = []
 for p in data:
     text = f"{p['name']} {p.get('kind','')} {' '.join(p.get('services', []))} {p.get('hours','')}"
     vec = embed_one(text)  # <-- FLAT VECTOR
-    # Optional sanity check:
     assert isinstance(vec, list) and all(
         isinstance(x, (int, float)) for x in vec
     ), f"Bad embedding shape: {type(vec)}"
-    # Write document
+
     doc = p | {"embedding": vec}
     slug = re.sub(r"[^a-z0-9]+", "-", p["name"].lower()).strip("-")
     geokey = f"{p.get('geo',{}).get('lat','')},{p.get('geo',{}).get('lon','')}"
     doc_id = hashlib.sha1(f"{slug}|{geokey}".encode("utf-8")).hexdigest()
-    es.index(index=INDEX, id=doc_id, document=doc)
-logging.info("Done indexing providers.")
+
+    actions.append(
+        {
+            "_op_type": "update",
+            "_index": INDEX,
+            "_id": doc_id,
+            "doc": doc,
+            "doc_as_upsert": True,
+        }
+    )
+
+helpers.bulk(es, actions)
+logging.info("Upserted %d providers into %s", len(actions), INDEX)

--- a/scripts/ingest_public_kb.py
+++ b/scripts/ingest_public_kb.py
@@ -5,7 +5,7 @@ import hashlib
 from datetime import datetime
 from typing import Any, List
 
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, helpers
 from sentence_transformers import SentenceTransformer
 from app.config import settings
 
@@ -34,11 +34,16 @@ def embed_one(text: str) -> List[float]:
     return _model.encode([text], normalize_embeddings=True)[0].tolist()
 
 
+paths = sorted(glob.glob("seeds/public_medical_kb/*.md"))
 logging.info(
-    f"Indexing public medical knowledge base into {INDEX} using model {MODEL}."
+    "Indexing %d public medical KB docs into %s using model %s.",
+    len(paths),
+    INDEX,
+    MODEL,
 )
 
-for path in glob.glob("seeds/public_medical_kb/*.md"):
+actions = []
+for path in paths:
     with open(path, "r", encoding="utf-8") as f:
         text = f.read()
 
@@ -65,7 +70,6 @@ for path in glob.glob("seeds/public_medical_kb/*.md"):
     }
 
     vec = embed_one(doc["title"] + "\n" + doc["text"])  # <-- FLAT LIST
-    # Guardrail to fail fast if shape is wrong
     assert (
         isinstance(vec, list)
         and len(vec) == VEC_DIMS
@@ -74,7 +78,16 @@ for path in glob.glob("seeds/public_medical_kb/*.md"):
 
     doc["embedding"] = vec
     doc_id = hashlib.sha1((source_url + "|" + section).encode("utf-8")).hexdigest()
-    es.index(index=INDEX, id=doc_id, document=doc)
-    logging.info(f"Indexed {path}")
 
-logging.info("Done indexing public medical knowledge base.")
+    actions.append(
+        {
+            "_op_type": "update",
+            "_index": INDEX,
+            "_id": doc_id,
+            "doc": doc,
+            "doc_as_upsert": True,
+        }
+    )
+
+helpers.bulk(es, actions)
+logging.info("Upserted %d KB docs into %s", len(actions), INDEX)


### PR DESCRIPTION
## Outcome
Make the seeding workflow rerunnable in CI/local runs without accumulating duplicates while still producing non-zero embeddings when the stub model is active.

## Demo
```bash
# ensure ES is running, then execute the seed scripts twice
docker compose run --rm seed
docker compose run --rm seed

# confirm doc counts stay stable (no duplicates)
curl -s http://localhost:9200/public_medical_kb/_count | jq
curl -s http://localhost:9200/providers_places/_count | jq
```

## Acceptance checks
- [x] **Unit / integration**: `venv/bin/pytest`
- [x] **i18n / locale**: N/A
- [x] **Observability**: Scripts log upsert operations and final counts.
- [x] **Safety / disclaimers**: Seed content unchanged; only ingestion mechanics updated.

## Scope
**Included**
- Swap the public KB and providers ingestion scripts to use Elasticsearch bulk upserts (`doc_as_upsert`) with deterministic IDs.
- Preserve stub embedding behaviour (one-hot vectors) so CI still emits non-zero embeddings.
- Minor logging improvements clarifying upsert counts.

**Excluded**
- No changes to private memory ingestion or ES mappings.
- Did not convert scripts to packages/CLI (kept single-file scripts).

## Data & provenance
No dataset changes; re-uses existing markdown/JSON seeds.

## Rollback / Flags
Revert commit `829b862` to restore previous one-shot indexing behaviour.

## Risks / Mitigations
- Bulk upsert failure → falls back to script error; reruns remain safe since operations are idempotent.
- Stub model logic remains if `EMBEDDINGS_MODEL=__stub__`.

## Docs & follow-up
- N/A.
