### PR TITLE
docs: publish architecture/config/evaluation guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Scope: These instructions apply to the whole repository. They are for AI coding 
 - `services/api/app/graph/nodes/` — pipeline nodes (supervisor, scrub, memory, health, risk_ml, places, planner, answer_gen, critic).
 - `services/api/app/graph/build.py` — LangGraph wiring and routing.
 - `services/api/app/tools/` — shared utilities (embeddings, ES client, crypto, language, etc.).
+- `docs/` — stable contributor references (architecture, configuration, evaluation guides).
 - `project/` — product docs: roadmap (`project/roadmap.md`, `project/roadmap/pr-stack.md`, `project/roadmap/shipped.md`, `project/roadmap/ideas.md`), direction (`project/vision.md`, `project/architecture.md`), and runbooks (`project/config.md`, `project/evaluation.md`, `project/privacy.md`, `project/troubleshooting.md`).
 - `seeds/` — seed KB and providers. E2E tests rely on this content.
 - `docker-compose.yml` — local dev stack; note mounted volumes.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The Body Agent is a multi-agent system orchestrated by LangGraph. It uses a loca
 - **Streaming API**: Real-time, node-by-node event streaming for a responsive UX.
 - **Encryption at Rest**: Per-user key encryption for private memory values.
 
+## Documentation
+
+- [Architecture](docs/architecture.md) — Graph topology, node responsibilities, and streaming contract.
+- [Configuration](docs/config.md) — Environment variables and mode profiles for dev, CI, and prod.
+- [Evaluation](docs/evaluation.md) — Test matrix, coverage gates, and QA checklist.
+
 ## Getting Started
 
 1.  **Prerequisites:**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Architecture
+
+This document captures the end-to-end layout of the Body Agent stack so new contributors can quickly reason about control flow, storage, and external dependencies. For a condensed checklist of the current milestone focus, see `project/architecture.md`.
+
+## Runtime Overview
+
+The runtime is a LangGraph-powered FastAPI service that streams node outputs over Server-Sent Events (SSE). Each user query flows through a deterministic graph of nodes:
+
+```
+scrub → supervisor → memory → { health | places } → risk_ml → planner → answer_gen → critic → final
+```
+
+- **scrub** — removes personally identifiable information (PII) and annotates the language before anything touches logging or downstream nodes.
+- **supervisor** — embeds the redacted query and routes to the correct intent/sub-intent using exemplar classifiers (EN/HE by default).
+- **memory** — fetches private, per-user context (meds, allergies, preferences) from Elasticsearch (`private_user_memory`). Secrets are encrypted at rest using the per-user key service.
+- **health** — retrieves public medical guidance from Elasticsearch (`public_medical_kb`) with a hybrid kNN + BM25 strategy, boosted by the symptom registry.
+- **places** — looks up providers/locations in Elasticsearch (`providers_places`) and applies deterministic ranking using stored preferences.
+- **risk_ml** — runs the risk classifier (either real NLI model or `__stub__`) and flags red/amber cases.
+- **planner** — builds structured plans (appointments, follow-ups, or no-op) and carries forward observability breadcrumbs.
+- **answer_gen** — renders deterministic recaps, optionally calls an LLM (Ollama/OpenAI) behind feature flags, and always attaches citations/disclaimers.
+- **critic** — enforces safety contracts: citations present, disclaimers intact, language matches, and no dosing claims slip through.
+
+The graph is strictly ordered for streaming. Nodes that are not part of the active branch (e.g., `places` when handling a pure meds-onset question) are skipped but the event order for emitted nodes is invariant.
+
+## API Surface
+
+- `POST /api/graph/run` — Executes the full graph and responds with `{ "state": { ... } }` once the final state is available.
+- `POST /api/graph/stream` — Streams graph progress as SSE chunks. Each chunk begins with `data:` and contains JSON. The terminal message always includes a `final` payload with the exact serialized state returned by `/api/graph/run`.
+
+### Streaming Contract
+
+1. `content-type` must be `text/event-stream`.
+2. At least one intermediate chunk contains a `delta` field indicating a node update.
+3. The last chunk **must** include `{"final": {"state": …}}` and no further messages follow.
+4. Error scenarios surface an `{"error": {...}}` chunk so clients can surface meaningful failures without inspecting server logs.
+
+## Data & Storage
+
+| Index / Store            | Purpose                                   | Notes |
+|--------------------------|-------------------------------------------|-------|
+| `private_user_memory`    | User-specific meds, allergies, preferences| AES-GCM encrypted values; filtered by `user_id`. |
+| `public_medical_kb`      | Medical snippets & guidance               | Hybrid kNN + BM25; language-filtered (`en`, `he`). |
+| `providers_places`       | Providers, labs, and scheduling metadata  | Geo filters + preference weighting. |
+| Seed JSON/YAML files     | Med facts, templates, symptom registry    | Mounted into containers; hot-reload supported where flagged. |
+
+All indices are seeded via the `seed` container. CI runs in stub mode so ingest scripts can be executed repeatedly without leaving dangling data (see `docs/config.md#ci-mode`).
+
+## External Services & Models
+
+- **Elasticsearch** — Backing store for memory, public knowledge, and provider data. Required in all modes.
+- **Embedding model** — Configurable via `EMBEDDINGS_MODEL`; defaults to `__stub__` in CI to avoid large downloads.
+- **Risk model** — Controlled by `RISK_MODEL_ID`; also supports the `__stub__` mode.
+- **LLM provider** — Optional. Set `LLM_PROVIDER=ollama` or `openai` to enable paraphrasing or fallback generation. When disabled, the system falls back to deterministic templates.
+
+## Feature Flags & Deterministic Paths
+
+Several flows are gated behind environment flags so we can ship incremental improvements safely:
+
+- `PARAPHRASE_ONSET` — Calls Ollama to rephrase deterministic meds-onset facts while validating that numerics remain unchanged.
+- `ONSET_LLM_FALLBACK` — Invokes an LLM when no vetted onset fact exists to produce a short, number-free neutral blurb.
+- `INTENT_EXEMPLARS_WATCH` / `FALLBACK_TEMPLATES_WATCH` — Enable hot-reloading of exemplar and template files in development.
+
+Feature flags always degrade gracefully to deterministic templates so CI and offline environments remain reliable.
+
+## Observability Hooks
+
+- **Structured logging** — All nodes emit structured log lines with `intent`, `user_id` (hashed), and timing information. PII is stripped at the scrubber boundary.
+- **Graph debug payload** — The running state carries `debug` fields (e.g., `debug.risk.triggered`, `debug.health.retrieval`) to aid in integration tests and inspection via the SSE stream.
+- **Coverage gates** — Pytest enforces ≥95% overall coverage and ≥90% per file, ensuring new code paths stay exercised.
+
+## Extending the Graph
+
+1. Add your node implementation under `services/api/app/graph/nodes/` and wire it into `services/api/app/graph/build.py`.
+2. Update `project/roadmap/pr-stack.md` with scope/acceptance criteria for the new work.
+3. Provide unit tests for business logic and, where relevant, extend integration tests to exercise the new node’s contract.
+4. Document any new configuration or seeds. Environment variables belong in `.env.example`, `docs/config.md`, and supporting references in `project/config.md`.
+
+Keeping these steps tight ensures future PRs stay small, testable, and aligned with the privacy-first charter.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,105 @@
+# Configuration Guide
+
+This guide centralises runtime knobs, defaults, and recommended settings for local development, CI, and production-like deployments. Mirror updates into `.env.example` whenever you introduce new variables.
+
+## Core Application Settings
+
+| Variable           | Default | Description |
+|--------------------|---------|-------------|
+| `APP_ENV`          | `dev`   | Execution mode (`dev`, `ci`, `test`, `prod`). Influences logging verbosity and stub usage. |
+| `HOST` / `PORT`    | `0.0.0.0` / `8000` | Bind address for the FastAPI server. |
+| `APP_DATA_DIR`     | `/data` | Path where exemplar/templates seeds are mounted inside containers. |
+| `APP_LOG_DIR`      | `/logs` | Directory for structured application logs. |
+| `LOG_LEVEL`        | `INFO`  | Standard Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
+
+## Elasticsearch
+
+| Variable             | Default               | Notes |
+|----------------------|-----------------------|-------|
+| `ES_HOST`            | `http://localhost:9200` | All indices live on the same cluster; override when running in Docker Compose. |
+| `ES_PRIVATE_INDEX`   | `private_user_memory` | Stores encrypted per-user facts. |
+| `ES_PUBLIC_INDEX`    | `public_medical_kb`   | Seeds contain vetted medical snippets. |
+| `ES_PLACES_INDEX`    | `providers_places`    | Geocoded providers and hours. |
+
+## Embeddings & Language Models
+
+| Variable              | Default    | Description |
+|-----------------------|------------|-------------|
+| `EMBEDDINGS_MODEL`    | `__stub__` | Sentence-transformer identifier or stub. Use a real model locally (e.g., `sentence-transformers/all-MiniLM-L6-v2`). |
+| `EMBEDDINGS_DEVICE`   | `cpu`      | Set to `cuda` to leverage GPU acceleration. |
+| `LLM_PROVIDER`        | `none`     | `none`, `ollama`, or `openai`. Controls whether answer generation invokes an LLM. |
+| `OLLAMA_MODEL`        | `nomic-embed-text` | Model served by the local Ollama instance. Only read when `LLM_PROVIDER=ollama`. |
+| `OLLAMA_HOST`         | `http://localhost:11434` | Target Ollama endpoint. |
+| `OPENAI_API_KEY`      | _unset_    | Required when `LLM_PROVIDER=openai`. Keep it out of version control. |
+
+## Risk Classification
+
+| Variable            | Default                                 | Usage |
+|---------------------|-----------------------------------------|-------|
+| `RISK_MODEL_ID`     | `__stub__`                              | Hugging Face model id or stub sentinel. |
+| `RISK_LABELS`       | `urgent_care,see_doctor,self_care,info_only` | Expected label ordering for classifiers. |
+| `RISK_THRESHOLDS`   | `urgent_care:0.55,see_doctor:0.50`      | Comma-delimited map of label → probability threshold. |
+| `RISK_HYPOTHESIS`   | Domain-specific NLI prompt used by the classifier. |
+| `RISK_ONSET_RED_FLAGS` | (unset)                             | Comma-delimited phrases that must always trigger ML evaluation even when heuristics would short-circuit. |
+
+## Intent Routing & Templates
+
+| Variable                 | Default                          | Description |
+|--------------------------|----------------------------------|-------------|
+| `INTENT_EXEMPLARS_PATH`  | `/app/data/intent_exemplars.jsonl` | File containing exemplar registry. |
+| `INTENT_EXEMPLARS_WATCH` | `false`                          | Enable to hot-reload exemplars on change (dev only). |
+| `INTENT_THRESHOLD`       | `0.30`                           | Minimum cosine similarity for a winning intent. |
+| `INTENT_MARGIN`          | `0.05`                           | Required gap between first and second candidates. |
+| `INTENT_LANGS`           | `en,he`                          | Languages that the exemplar registry supports. |
+| `SYMPTOM_REGISTRY_PATH`  | `/app/registry/symptoms.yml`     | Canonical symptom definitions and doc pointers. |
+| `FALLBACK_TEMPLATES_PATH`| _unset_                          | Optional JSON file with safety templates (EN/HE). |
+| `FALLBACK_TEMPLATES_WATCH` | `false`                        | Hot-reload pattern templates in development. |
+
+## Deterministic Meds Onset
+
+| Variable             | Default                     | Description |
+|----------------------|-----------------------------|-------------|
+| `MED_FACTS_PATH`     | `/app/seeds/med_facts.json` | Seeded fact registry for vetted onset windows. |
+| `PARAPHRASE_ONSET`   | `false`                     | When true, calls Ollama to paraphrase deterministic onset copy while enforcing numeric invariants. |
+| `ONSET_LLM_FALLBACK` | `false`                     | Enables a number-free LLM blurb when no onset fact exists. |
+
+## Mode Profiles
+
+### CI Mode (deterministic)
+
+Used in GitHub Actions and local `make e2e-local` runs when reproducibility matters.
+
+```
+APP_ENV=ci
+EMBEDDINGS_MODEL=__stub__
+RISK_MODEL_ID=__stub__
+LLM_PROVIDER=none
+PARAPHRASE_ONSET=false
+ONSET_LLM_FALLBACK=false
+```
+
+The `seed` container populates Elasticsearch with stub embeddings and deterministic vectors. Re-running the ingest scripts is idempotent (see `docs/evaluation.md#seed-resets`).
+
+### Local Development (full models)
+
+```
+APP_ENV=dev
+EMBEDDINGS_MODEL=sentence-transformers/all-MiniLM-L6-v2
+RISK_MODEL_ID=MoritzLaurer/mDeBERTa-v3-base-mnli-xnli
+LLM_PROVIDER=ollama
+OLLAMA_MODEL=openhermes
+PARAPHRASE_ONSET=true
+ONSET_LLM_FALLBACK=true
+```
+
+Feel free to tweak embedding/LLM identifiers according to GPU availability. Keep exemplar and template files inside `APP_DATA_DIR` to leverage hot reloaders.
+
+### Production Preview
+
+`APP_ENV=prod` currently behaves like `dev` but should be configured with:
+
+- Hardened secrets (via Docker secrets or your orchestrator).
+- Remote Elasticsearch cluster endpoints.
+- LLM provider credentials fetched from a secret store instead of environment variables committed to disk.
+
+Document any additional production-only knobs alongside runbooks in `project/config.md`.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,56 @@
+# Evaluation & Quality Gates
+
+Reliable behaviour is enforced through layered tests, curated seeds, and coverage thresholds. This document explains how to exercise those layers and what constitutes a blocking failure.
+
+## Test Matrix
+
+| Layer         | Command                                   | Purpose |
+|---------------|--------------------------------------------|---------|
+| Unit          | `venv/bin/pytest services/api/tests/unit`  | Verify individual nodes, tools, and helpers in isolation. |
+| Integration   | `venv/bin/pytest services/api/tests/integration` | Exercise the assembled FastAPI app with stubbed models. |
+| Coverage gate | `venv/bin/pytest --cov --cov-report=term-missing` | Enforce ≥95% overall coverage and ≥90% per file via pytest exit codes. |
+| Golden evals  | `make eval`                                | Quick regression pass over curated prompt/response pairs. |
+| End-to-end    | `make e2e-local`                           | Boots Elasticsearch + API in stub mode and runs the full client flow. |
+
+CI runs the unit + integration suite with coverage by default. Golden and E2E suites are required when touching retrieval, routing, or ingest flows.
+
+## Acceptance Criteria by Surface
+
+- **Retrieval fidelity** — Seeded symptoms must surface at least one relevant snippet (see `services/api/tests/unit/test_health.py`). If BM25 or kNN miss, adjust boosts instead of broadening templates.
+- **Risk gating** — `services/api/tests/unit/test_risk_and_critic.py` enforces threshold compliance; regressions that reduce sensitivity below configured levels are release blockers.
+- **Streaming contract** — Integration tests assert the presence of streaming deltas, terminal `final` events, and well-formed JSON (`test_graph_stream_basic_query`).
+- **Meds onset determinism** — Unit tests cover med facts loading, paraphrase validation, and LLM fallback guardrails. Any new flow must leave citations and disclaimers intact.
+
+## Seeds & Reproducibility
+
+- `seeds/med_facts.json` — Vet meds onset windows; always update alongside tests.
+- `seeds/public_medical_kb/` — Markdown snippets consumed by health retrieval; update the E2E fixtures if adding new docs.
+- `seeds/providers/` — Deterministic provider catalog for ranking tests.
+- In CI, the seed container ensures ingest scripts are idempotent and stub vectors are non-zero. If you add a new seed input, provide a deterministic stub representation for tests.
+
+### Seed Resets
+
+During iterative development you can rerun the ingest scripts:
+
+```bash
+docker compose run --rm seed python scripts/ingest_public_kb.py
+```
+
+Scripts upsert documents by `_id`, so reruns are safe. If you modify schema fields, bump the `_id` or include migrations in the same PR.
+
+## Manual QA Checklist
+
+Before shipping a user-facing change:
+
+1. Stream a symptom query (`/api/graph/stream`) and confirm SSE ordering, citations, and disclaimer text.
+2. Exercise a meds-onset flow with and without feature flags to ensure deterministic fallbacks still work.
+3. Run `make e2e-local` if retrieval indices or ingest logic changed.
+4. Capture demo steps (≤90s) for the PR template using reproducible commands.
+
+## Tooling & Reporting
+
+- **Coverage reports** — Use `--cov-report=term-missing` to identify uncovered lines. Annotate follow-up tickets if coverage cannot exceed 95% due to third-party code.
+- **Pre-commit** — Run `pre-commit run --all-files` before pushing. Hooks include Ruff, Black, MyPy, and secret detection.
+- **CI dashboards** — GitHub Actions expose pytest XML, coverage, and lint summaries. Treat any warning about coverage regression as a blocking issue.
+
+Keeping these guardrails in place ensures we ship incremental improvements without compromising safety or determinism.

--- a/project/roadmap/pr-stack.md
+++ b/project/roadmap/pr-stack.md
@@ -6,10 +6,6 @@ Refer to `project/roadmap/shipped.md` for completed slices.
 
 # Milestone 3 — Stability & CI polish
 
-## PR 29 — Docs: architecture/config/evaluation roll-up
-
-- Publish the drafted docs (`docs/architecture.md`, `docs/config.md`, `docs/evaluation.md`) and link from README.
-
 ---
 
 # Milestone 4 — Intent + privacy hardening

--- a/project/roadmap/shipped.md
+++ b/project/roadmap/shipped.md
@@ -8,6 +8,12 @@ Chronicles of recently completed work. Each entry mirrors the acceptance criteri
 - Ensured the SSE test reuses parsed payloads instead of re-reading the raw stream, avoiding duplicate parsing logic.
 - Verified error-path coverage still emits an `error` event when streaming fails.
 
+## PR 29 — Docs: architecture/config/evaluation roll-up
+
+- Published durable contributor docs under `docs/`: architecture overview, configuration matrix, and evaluation guide.
+- Linked the new documentation from `README.md` so newcomers can find architecture, config, and quality guardrails.
+- Clarified seed idempotency and testing expectations to keep deterministic workflows aligned with CI.
+
 ## PR 27 — Seed container idempotent + stub-aware
 
 - Updated `scripts/ingest_public_kb.py` and `scripts/ingest_providers.py` to upsert on `_id`, skip redundant writes, and fill stub vectors so reruns leave ES ready for tests.


### PR DESCRIPTION
## Outcome
Documentation now has dedicated architecture, configuration, and evaluation guides that match the current graph implementation and quality bar.

## Demo
Docs-only change; no runtime behaviour to demo.

## Acceptance checks
- [x] **Unit / integration**: `pre-commit run --files README.md docs/architecture.md docs/config.md docs/evaluation.md`
- [ ] **i18n / locale**: N/A (docs-only change)
- [ ] **Observability**: N/A (docs-only change)
- [ ] **Safety / disclaimers**: N/A (docs-only change)

## Scope
**Included**
- Publish `docs/architecture.md`, `docs/config.md`, and `docs/evaluation.md` with up-to-date guidance.
- Link the new docs from `README.md` and note the directory in `AGENTS.md`.
- Move PR 29 to shipped in the roadmap.

**Excluded**
- Additional product roadmap updates beyond PR 29.
- Changes to runtime code or tests.

## Data & provenance
Docs-only; no datasets or seeds updated.

## Rollback / Flags
Revert the PR; no feature flags involved.

## Risks / Mitigations
Low risk—documentation updates only.

## Docs & follow-up
- README.md (links) — this PR
- docs/architecture.md — new
- docs/config.md — new
- docs/evaluation.md — new
