### PR TITLE
fix: harden intent exemplar watcher

### DIFF
--- a/services/api/app/graph/nodes/supervisor.py
+++ b/services/api/app/graph/nodes/supervisor.py
@@ -10,11 +10,11 @@ from app.tools.embeddings import embed
 from app.tools.med_normalize import find_medications_in_text
 
 # ---- Config ----
-_EX_PATH = os.getenv("INTENT_EXEMPLARS_PATH")
 _THRESHOLD = float(os.getenv("INTENT_THRESHOLD", "0.30"))
 _MARGIN = float(os.getenv("INTENT_MARGIN", "0.05"))
 _WATCH = os.getenv("INTENT_EXEMPLARS_WATCH", "false").strip().lower() == "true"
-_EX_MTIME: Optional[float] = None
+_EX_MTIME_NS: Optional[int] = None
+_ACTIVE_PATH: Optional[str] = None
 
 _DEFAULT_EXAMPLES: Dict[str, List[str]] = {
     "symptom": [
@@ -95,10 +95,25 @@ def _parse_jsonl_exemplars(lines: List[str]) -> Dict[str, List[str]]:
     return {k: v for k, v in buckets.items() if v}
 
 
+def _current_path() -> Optional[str]:
+    path = os.getenv("INTENT_EXEMPLARS_PATH", "").strip()
+    return path or None
+
+
+def _stat_mtime_ns(path: str) -> Optional[int]:
+    try:
+        stat_result = os.stat(path)
+    except OSError:
+        return None
+    return getattr(
+        stat_result, "st_mtime_ns", int(stat_result.st_mtime * 1_000_000_000)
+    )
+
+
 def _load_exemplars() -> Dict[str, List[str]]:
     # Load exemplars from file if provided; otherwise defaults
-    global _EX_MTIME
-    path = _EX_PATH
+    global _EX_MTIME_NS, _ACTIVE_PATH
+    path = _current_path()
     if path and os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as f:
@@ -107,25 +122,30 @@ def _load_exemplars() -> Dict[str, List[str]]:
                 else:
                     data = _parse_json_exemplars(json.load(f))
             if data:
-                try:
-                    _EX_MTIME = os.path.getmtime(path)
-                except OSError:
-                    _EX_MTIME = None
+                _ACTIVE_PATH = path
+                _EX_MTIME_NS = _stat_mtime_ns(path)
                 logging.info(f"Loaded intent exemplars from {path}")
                 return data
             logging.warning(
                 f"Exemplars file {path} is empty or malformed, using default exemplars."
             )
+            _ACTIVE_PATH = path
+            _EX_MTIME_NS = _stat_mtime_ns(path)
             return _DEFAULT_EXAMPLES
         except (OSError, json.JSONDecodeError) as e:
             logging.error(
                 f"Failed to load intent exemplars from {path}: {e}", exc_info=True
             )
             logging.info("Using default intent exemplars.")
+            _ACTIVE_PATH = path
+            _EX_MTIME_NS = _stat_mtime_ns(path)
             return _DEFAULT_EXAMPLES
-    logging.info(
-        "INTENT_EXEMPLARS_PATH not set or file not found, using default exemplars."
-    )
+    if path:
+        logging.info(
+            "INTENT_EXEMPLARS_PATH not set or file not found, using default exemplars."
+        )
+    _ACTIVE_PATH = None
+    _EX_MTIME_NS = None
     return _DEFAULT_EXAMPLES
 
 
@@ -147,20 +167,28 @@ _rebuild_vectors()
 def _maybe_reload() -> None:
     if not _WATCH:
         return
-    path = _EX_PATH
-    if not path or not os.path.exists(path):
-        return
-    try:
-        mtime = os.path.getmtime(path)
-    except OSError:
-        return
-    global _EX_MTIME, _EXEMPLARS
-    if _EX_MTIME is None or mtime > _EX_MTIME:
+    path = _current_path()
+    global _ACTIVE_PATH, _EX_MTIME_NS, _EXEMPLARS
+    if path != _ACTIVE_PATH:
         new_map = _load_exemplars()
-        if new_map:
-            _EXEMPLARS = new_map
-            _rebuild_vectors()
-            logging.info("Reloaded intent exemplars after file change")
+        _EXEMPLARS = new_map
+        _rebuild_vectors()
+        logging.info("Reloaded intent exemplars after path change")
+        return
+    if not path:
+        return
+    mtime_ns = _stat_mtime_ns(path)
+    if mtime_ns is None:
+        new_map = _load_exemplars()
+        _EXEMPLARS = new_map
+        _rebuild_vectors()
+        logging.info("Reloaded intent exemplars after file became unavailable")
+        return
+    if _EX_MTIME_NS is None or mtime_ns > _EX_MTIME_NS:
+        new_map = _load_exemplars()
+        _EXEMPLARS = new_map
+        _rebuild_vectors()
+        logging.info("Reloaded intent exemplars after file change")
 
 
 def detect_intent(


### PR DESCRIPTION
## Outcome
Supervisor now hot-reloads intent exemplars reliably: we detect file edits with ns-resolution stat checks and react when `INTENT_EXEMPLARS_PATH` is switched, so the watcher works end-to-end in dev.

## Demo
```bash
venv/bin/pytest services/api/tests/unit/test_supervisor.py -k exemplars
```

## Acceptance checks
- [x] **Unit / integration**: `venv/bin/pytest`
- [ ] **i18n / locale**: N/A (logic change only)
- [x] **Observability**: log messages now indicate reload triggers for file edits/path changes
- [ ] **Safety / disclaimers**: N/A

## Scope
**Included**
- Refactor exemplar loader/watch state to track active path + mtime_ns and refresh vectors when the path or file changes.
- Expand unit coverage to temp-file harnesses (JSON/JSONL, malformed/empty) and verify both mtime bumps and path switches trigger reloads.

**Excluded**
- No changes to exemplar contents themselves or embedding thresholds.
- No modifications to watcher toggles outside supervisor.

## Data & provenance
Docs-only change to tests/code references temp files; no seeds or datasets touched.

## Rollback / Flags
Disable `INTENT_EXEMPLARS_WATCH` or revert this commit.

## Risks / Mitigations
Low risk; affects watch mode only. Unit tests cover happy-path reloads and error handling.

## Docs & follow-up
- N/A
