### PR TITLE
feat: expand scrubber for gov ids and addresses

### DIFF
--- a/project/roadmap/pr-stack.md
+++ b/project/roadmap/pr-stack.md
@@ -10,10 +10,6 @@ Refer to `project/roadmap/shipped.md` for completed slices.
 
 # Milestone 4 — Intent + privacy hardening
 
-## PR 30 — Intent exemplar refresh + hot reload polish
-
-- Ensure `INTENT_EXEMPLARS_PATH` watcher works end-to-end; add unit coverage for loader.
-
 ## PR 31 — PII scrub expansion
 
 - Extend scrubber regexes for gov IDs and address fragments; redact to `[gov_id]` / `[address]`; cover with unit tests.

--- a/project/roadmap/shipped.md
+++ b/project/roadmap/shipped.md
@@ -14,6 +14,12 @@ Chronicles of recently completed work. Each entry mirrors the acceptance criteri
 - Linked the new documentation from `README.md` so newcomers can find architecture, config, and quality guardrails.
 - Clarified seed idempotency and testing expectations to keep deterministic workflows aligned with CI.
 
+## PR 30 — Intent exemplar refresh + hot reload polish
+
+- Supervisor watcher now tracks both exemplar file path and `st_mtime_ns`, reloading cleanly on edits, deletes, or path changes.
+- `_load_exemplars` uses real temp files in unit tests to cover JSON/JSONL parsing, malformed content, and dynamic watcher behaviour.
+- Full test suite passes with deterministic reload coverage to support hot-reload workflows.
+
 ## PR 27 — Seed container idempotent + stub-aware
 
 - Updated `scripts/ingest_public_kb.py` and `scripts/ingest_providers.py` to upsert on `_id`, skip redundant writes, and fill stub vectors so reruns leave ES ready for tests.

--- a/services/api/app/graph/nodes/scrub.py
+++ b/services/api/app/graph/nodes/scrub.py
@@ -8,22 +8,39 @@ from app.tools.language import (
 )
 
 
+_CREDIT_CARD_RE = re.compile(r"\b\d{4}[\s\-]?\d{4}[\s\-]?\d{4}[\s\-]?\d{4}\b")
+_SSN_RE = re.compile(r"\b\d{3}[\s\-]?\d{2}[\s\-]?\d{4}\b")
+_GOV_ID_RE = re.compile(
+    r"\b(?:social security number|passport(?: number)?|national id|gov(?:ernment)? id|id(?: number)?|license(?: number)?|תעודת זהות|ת\.ז\.?)\s*[:#]?\s*(?:[A-Za-z0-9\-]{3,}|\[ssn\])",
+    flags=re.IGNORECASE,
+)
+_PHONE_RE = re.compile(r"\s*\b[+]?\d[\d\s\-]{7,}\b\s*")
+_STREET_SUFFIXES = (
+    "street|st|avenue|ave|road|rd|boulevard|blvd|lane|ln|drive|dr|court|ct|"
+    "way|place|pl|terrace|ter|circle|cir"
+)
+_ADDR_EN_RE = re.compile(
+    rf"\b\d{{1,5}}\s+(?:[A-Za-z\u0590-\u05FF]+\s+){{0,5}}(?:{_STREET_SUFFIXES})\b\.?",
+    flags=re.IGNORECASE,
+)
+_ADDR_HE_RE = re.compile(
+    r"\b(?:[בל]?רחוב)\s+(?:[^\s\d]+\s*)+\d{1,4}\b",
+    flags=re.UNICODE,
+)
+_EMAIL_RE = re.compile(r"\s*[\w\.-]+@[\w\.-]+\s*")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
 def run(state: BodyState) -> BodyState:
     txt = state.get("user_query", "")
-    # Credit card numbers (most specific first)
-    red = re.sub(r"\b\d{4}[\s\-]?\d{4}[\s\-]?\d{4}[\s\-]?\d{4}\b", "[credit-card]", txt)
-
-    # Social security numbers (US format)
-    red = re.sub(r"\b\d{3}[\s\-]?\d{2}[\s\-]?\d{4}\b", "[ssn]", red)
-
-    # Phone numbers (including international)
-    red = re.sub(r"\s*\b[+]?\d[\d\s\-]{7,}\b\s*", " [phone] ", red)
-
-    # Email addresses
-    red = re.sub(r"\s*[\w\.-]+@[\w\.-]+\s*", " [email] ", red)
-
-    # Clean up extra spaces
-    red = re.sub(r"\s+", " ", red).strip()
+    red = _CREDIT_CARD_RE.sub("[credit-card]", txt)
+    red = _SSN_RE.sub("[ssn]", red)
+    red = _GOV_ID_RE.sub(" [gov_id] ", red)
+    red = _PHONE_RE.sub(" [phone] ", red)
+    red = _ADDR_EN_RE.sub(" [address] ", red)
+    red = _ADDR_HE_RE.sub(" [address] ", red)
+    red = _EMAIL_RE.sub(" [email] ", red)
+    red = _WHITESPACE_RE.sub(" ", red).strip()
 
     # Create a new state dict with the base required fields
     new_state = dict(state)  # Make a copy

--- a/services/api/tests/unit/test_scrub.py
+++ b/services/api/tests/unit/test_scrub.py
@@ -22,3 +22,44 @@ def test_scrub_keeps_english_without_pivot():
     out = scrub.run(state)
     assert out["language"] == "en"
     assert "user_query_pivot" not in out
+
+
+def test_scrub_redacts_government_ids():
+    query = "My passport number AB123456 is expired and ID 987654321 needs renewal"
+    state: BodyState = {"user_query": query}
+    out = scrub.run(state)
+    redacted = out["user_query_redacted"].lower()
+    assert "[gov_id]" in redacted
+    assert "ab123456" not in redacted
+    assert "987654321" not in redacted
+
+
+def test_scrub_redacts_hebrew_id_and_address():
+    query = "תעודת זהות 123456789 ברחוב אבן גבירול 15 תל אביב"
+    state: BodyState = {"user_query": query}
+    out = scrub.run(state)
+    redacted = out["user_query_redacted"]
+    assert "[gov_id]" in redacted
+    assert "[address]" in redacted
+    assert "123456789" not in redacted
+    assert "אבן גבירול 15" not in redacted
+
+
+def test_scrub_redacts_address_fragments():
+    query = "Send the package to 742 Evergreen Terrace tomorrow"
+    state: BodyState = {"user_query": query}
+    out = scrub.run(state)
+    redacted = out["user_query_redacted"].lower()
+    assert "[address]" in redacted
+    assert "742" not in redacted
+    assert "evergreen terrace" not in redacted
+
+
+def test_scrub_redacts_long_english_street():
+    query = "Mail it to 1200 Martin Luther King Jr Boulevard tonight"
+    state: BodyState = {"user_query": query}
+    out = scrub.run(state)
+    redacted = out["user_query_redacted"].lower()
+    assert "[address]" in redacted
+    assert "1200" not in redacted
+    assert "martin luther king jr boulevard" not in redacted


### PR DESCRIPTION
## Outcome
Scrubber now redacts government identification numbers and street address fragments, replacing them with `[gov_id]` and `[address]` while keeping existing PII handling intact.

## Demo
```bash
venv/bin/pytest services/api/tests/unit/test_scrub.py
```

## Acceptance checks
- [x] **Unit / integration**: `venv/bin/pytest`
- [ ] **i18n / locale**: Covered implicitly via Hebrew fixture in new tests
- [ ] **Observability**: N/A
- [x] **Safety / disclaimers**: Verified additional PII redaction paths

## Scope
**Included**
- New regexes for passport/ID phrases and common street formats (EN + HE) with replacements to `[gov_id]` / `[address]`.
- Unit coverage proving English/Hebrew IDs and addresses redact correctly.
- Roadmap updates marking PR 30 shipped.

**Excluded**
- Broader address detection (e.g., PO boxes, apartment numbers without street suffixes).
- Changes to downstream nodes consuming redacted text.

## Data & provenance
No datasets or seeds touched.

## Rollback / Flags
Revert this PR.

## Risks / Mitigations
Regexes are scoped to explicit cues (ID keywords, street suffixes) to avoid over-redaction; unit tests cover representative cases.

## Docs & follow-up
- `project/roadmap/pr-stack.md`
- `project/roadmap/shipped.md`
