### PR TITLE
feat(eval): add risk golden harness + eval-risk target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,8 @@ e2e-local-clean:
 eval:
 	@echo "[eval] Running golden evaluation tests..."
 	PYTHONPATH=services/api $(PYTEST) --no-cov services/api/tests/golden
+
+.PHONY: eval-risk
+eval-risk:
+	@echo "[eval-risk] Running risk golden evaluation..."
+	PYTHONPATH=services/api RISK_MODEL_ID=__stub__ $(PYTEST) --no-cov services/api/tests/golden/risk -q

--- a/seeds/evals/risk/en.jsonl
+++ b/seeds/evals/risk/en.jsonl
@@ -1,0 +1,4 @@
+{"text": "I have severe chest pain and shortness of breath.", "note": "should rank urgent_care highest"}
+{"text": "I feel unwell and might need to see a doctor soon.", "note": "see_doctor should be relatively high"}
+{"text": "Just looking for general information about a mild headache.", "note": "info_only/self_care context"}
+{"text": "I have some nose bleeding after an injury.", "note": "bleeding term present"}

--- a/services/api/tests/golden/risk/test_eval_risk.py
+++ b/services/api/tests/golden/risk/test_eval_risk.py
@@ -1,0 +1,64 @@
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _load_cases(root: Path) -> list[dict]:
+    cases: list[dict] = []
+    for p in root.glob("*.jsonl"):
+        for line in p.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                cases.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return cases
+
+
+@pytest.mark.skipif(
+    not Path("seeds/evals/risk").exists(), reason="no risk eval seeds present"
+)
+def test_eval_risk_golden(monkeypatch, capsys):
+    # Force stub pipeline for deterministic results
+    monkeypatch.setenv("RISK_MODEL_ID", "__stub__")
+    from app.graph.nodes import risk_ml
+
+    pipe = risk_ml._get_pipe()
+    assert pipe is not None
+    labels = [
+        s.strip()
+        for s in os.getenv(
+            "RISK_LABELS", "urgent_care,see_doctor,self_care,info_only"
+        ).split(",")
+        if s.strip()
+    ]
+
+    seeds_root = Path("seeds/evals/risk")
+    cases = _load_cases(seeds_root)
+    assert cases, "no risk golden cases found"
+
+    results: list[tuple[str, str]] = []  # (top_label, text)
+    for c in cases:
+        text = c.get("text", "")
+        # Run classifier; select top-scoring label
+        out = pipe(text, candidate_labels=labels, multi_label=True)
+        lab = out.get("labels", [])
+        sco = out.get("scores", [])
+        if lab and sco:
+            top = max(zip(lab, sco), key=lambda kv: float(kv[1]))[0]
+        else:
+            top = "<none>"
+        results.append((top, text))
+
+    # Print a compact summary; do not fail by default
+    counts: dict[str, int] = {}
+    for top, _ in results:
+        counts[top] = counts.get(top, 0) + 1
+    print("Risk golden summary:", counts)
+    captured = capsys.readouterr()
+    # Ensure we printed something meaningful
+    assert "Risk golden summary:" in captured.out

--- a/services/api/tests/golden/risk/test_eval_risk.py
+++ b/services/api/tests/golden/risk/test_eval_risk.py
@@ -7,15 +7,17 @@ import pytest
 
 def _load_cases(root: Path) -> list[dict]:
     cases: list[dict] = []
-    for p in root.glob("*.jsonl"):
-        for line in p.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
+    for path in root.glob("*.jsonl"):
+        for idx, raw in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            line = raw.strip()
             if not line:
                 continue
             try:
                 cases.append(json.loads(line))
-            except json.JSONDecodeError:
-                pass
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Malformed JSON at {path}:{idx}: {exc}") from exc
     return cases
 
 
@@ -41,7 +43,7 @@ def test_eval_risk_golden(monkeypatch, capsys):
     cases = _load_cases(seeds_root)
     assert cases, "no risk golden cases found"
 
-    results: list[tuple[str, str]] = []  # (top_label, text)
+    top_labels: list[str] = []
     for c in cases:
         text = c.get("text", "")
         # Run classifier; select top-scoring label
@@ -52,12 +54,12 @@ def test_eval_risk_golden(monkeypatch, capsys):
             top = max(zip(lab, sco), key=lambda kv: float(kv[1]))[0]
         else:
             top = "<none>"
-        results.append((top, text))
+        top_labels.append(top)
 
     # Print a compact summary; do not fail by default
     counts: dict[str, int] = {}
-    for top, _ in results:
-        counts[top] = counts.get(top, 0) + 1
+    for label in top_labels:
+        counts[label] = counts.get(label, 0) + 1
     print("Risk golden summary:", counts)
     captured = capsys.readouterr()
     # Ensure we printed something meaningful


### PR DESCRIPTION
Adds seeds/evals/risk/en.jsonl and a golden evaluation test under services/api/tests/golden/risk that runs the risk classifier in stub mode and prints a compact label summary. New Makefile target eval-risk runs just this suite with --no-cov. This is a non-gating eval; CI gating can be enabled later by adding a tolerance check.

Usage:
  make eval-risk
