### PR TITLE
feat(security): add outbound domain allow-list helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,6 @@ FALLBACK_TEMPLATES_WATCH=false
 
 # Symptom registry (doc routing + query expansions)
 SYMPTOM_REGISTRY_PATH=/app/registry/symptoms.yml
+
+# Outbound HTTP safety (allow-list; leave empty to allow all)
+OUTBOUND_ALLOWLIST=

--- a/docs/config.md
+++ b/docs/config.md
@@ -107,4 +107,4 @@ Document any additional production-only knobs alongside runbooks in `project/con
 ## Observability
 
 - `X-Request-ID` header: Clients may supply a request identifier per call. The API will normalize UUIDs and propagate the value through `state.debug.request_id` and include it on every SSE event. If omitted, the API generates a UUIDv4. Logs include `rid=<id>` to correlate runs and streams.
-- `OUTBOUND_ALLOWLIST`: Comma-separated list of domains that outbound HTTP calls may reach (matches subdomains). Leave empty to allow any domain. The new `safe_request` / `safe_get` helpers in `app.tools.http` enforce this list and raise `OutboundDomainError` when a URL is not permitted.
+- `OUTBOUND_ALLOWLIST`: Comma-separated list of domains that outbound HTTP calls may reach (matches subdomains). Leave empty to allow any domain. The new `safe_request` / `safe_get` helpers in `app.tools.http` enforce this list and raise `OutboundDomainError` when a URL (or IP) is not permitted. Automatic redirects are disabled by default so every hop must be validated explicitly.

--- a/docs/config.md
+++ b/docs/config.md
@@ -107,3 +107,4 @@ Document any additional production-only knobs alongside runbooks in `project/con
 ## Observability
 
 - `X-Request-ID` header: Clients may supply a request identifier per call. The API will normalize UUIDs and propagate the value through `state.debug.request_id` and include it on every SSE event. If omitted, the API generates a UUIDv4. Logs include `rid=<id>` to correlate runs and streams.
+- `OUTBOUND_ALLOWLIST`: Comma-separated list of domains that outbound HTTP calls may reach (matches subdomains). Leave empty to allow any domain. The new `safe_request` / `safe_get` helpers in `app.tools.http` enforce this list and raise `OutboundDomainError` when a URL is not permitted.

--- a/project/config.md
+++ b/project/config.md
@@ -8,6 +8,7 @@ This page lists the key environment variables, defaults, and how to run in CI (s
 - `HOST`, `PORT` (API bind)
 - `APP_DATA_DIR` (default `/data` inside containers)
 - `APP_LOG_DIR` (default `/logs`)
+- `OUTBOUND_ALLOWLIST` (comma-separated domains or IPs; leave empty to allow all). Requests must use `safe_request`/`safe_get`, which reject destinations outside the allow-list and disable automatic redirects.
 
 ## Elasticsearch
 

--- a/services/api/app/tools/http.py
+++ b/services/api/app/tools/http.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable, Mapping, Any
+from urllib.parse import urlparse
+
+import requests
+
+
+class OutboundDomainError(RuntimeError):
+    """Raised when a URL violates the configured outbound domain allow-list."""
+
+
+def _parse_allowlist(spec: str | None = None) -> set[str]:
+    raw = spec if spec is not None else os.getenv("OUTBOUND_ALLOWLIST", "")
+    return {item.strip().lower() for item in raw.split(",") if item and item.strip()}
+
+
+def _host_matches(host: str, allowed: Iterable[str]) -> bool:
+    host_lc = host.lower()
+    for entry in allowed:
+        entry_lc = entry.lower()
+        if host_lc == entry_lc or host_lc.endswith(f".{entry_lc}"):
+            return True
+    return False
+
+
+def safe_request(
+    method: str,
+    url: str,
+    *,
+    allowlist: Iterable[str] | None = None,
+    headers: Mapping[str, str] | None = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Perform an HTTP request enforcing the outbound domain allow-list.
+
+    If `allowlist` is provided, it overrides the value sourced from
+    `OUTBOUND_ALLOWLIST`. When no allow-list entries exist, all domains are
+    permitted. Subdomains automatically match their parent entry.
+    """
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Unsupported URL scheme: {parsed.scheme!r}")
+
+    host = parsed.hostname or ""
+    allowed = list(allowlist) if allowlist is not None else list(_parse_allowlist())
+    if allowed and not _host_matches(host, allowed):
+        raise OutboundDomainError(
+            f"Domain '{host}' is not permitted (allowed: {', '.join(allowed) or 'none'})"
+        )
+
+    return requests.request(method.upper(), url, headers=headers, **kwargs)
+
+
+def safe_get(
+    url: str,
+    *,
+    allowlist: Iterable[str] | None = None,
+    headers: Mapping[str, str] | None = None,
+    **kwargs: Any,
+) -> requests.Response:
+    """Convenience wrapper for GET requests that respect the domain allow-list."""
+
+    return safe_request("GET", url, allowlist=allowlist, headers=headers, **kwargs)
+
+
+__all__ = ["OutboundDomainError", "safe_request", "safe_get"]

--- a/services/api/app/tools/http.py
+++ b/services/api/app/tools/http.py
@@ -46,9 +46,9 @@ def safe_request(
 
     host = parsed.hostname or ""
     allowed_config = (
-        [entry.lower() for entry in allowlist]
+        {item.strip().lower() for item in allowlist if item.strip()}
         if allowlist is not None
-        else list(_parse_allowlist())
+        else _parse_allowlist()
     )
 
     if allowed_config:
@@ -62,12 +62,12 @@ def safe_request(
         if is_ip:
             if host.lower() not in allowed_config:
                 raise OutboundDomainError(
-                    f"IP '{host}' is not permitted (allowed: {', '.join(allowed_config)})"
+                    f"IP '{host}' is not permitted (allowed: {', '.join(sorted(allowed_config))})"
                 )
         else:
             if not _host_matches(host, allowed_config):
                 raise OutboundDomainError(
-                    f"Domain '{host}' is not permitted (allowed: {', '.join(allowed_config)})"
+                    f"Domain '{host}' is not permitted (allowed: {', '.join(sorted(allowed_config))})"
                 )
 
     allow_redirects = kwargs.pop("allow_redirects", False)

--- a/services/api/tests/unit/test_http.py
+++ b/services/api/tests/unit/test_http.py
@@ -1,0 +1,72 @@
+import pytest
+
+from app.tools import http
+
+
+class DummyResponse:
+    def __init__(self, url: str):
+        self.url = url
+
+
+def test_safe_request_allows_exact_domain(monkeypatch):
+    captured = {}
+
+    def fake_request(method, url, headers=None, **kwargs):
+        captured["method"] = method
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["kwargs"] = kwargs
+        return DummyResponse(url)
+
+    monkeypatch.setattr(http.requests, "request", fake_request)
+
+    resp = http.safe_request(
+        "get",
+        "https://example.com/path",
+        allowlist=["example.com"],
+        headers={"x": "y"},
+        timeout=5,
+    )
+
+    assert isinstance(resp, DummyResponse)
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://example.com/path"
+    assert captured["headers"] == {"x": "y"}
+    assert captured["kwargs"]["timeout"] == 5
+
+
+def test_safe_request_allows_subdomain(monkeypatch):
+    def fake_request(method, url, **kwargs):
+        return DummyResponse(url)
+
+    monkeypatch.setattr(http.requests, "request", fake_request)
+    resp = http.safe_get("https://api.example.com/data", allowlist=["example.com"])
+    assert isinstance(resp, DummyResponse)
+
+
+def test_safe_request_blocks_unlisted_domain(monkeypatch):
+    monkeypatch.setattr(
+        http.requests, "request", lambda *a, **k: DummyResponse("blocked")
+    )
+    with pytest.raises(http.OutboundDomainError):
+        http.safe_get("https://other.com/", allowlist=["example.com"])
+
+
+def test_safe_request_no_allowlist_allows_all(monkeypatch):
+    monkeypatch.setattr(http.requests, "request", lambda *a, **k: DummyResponse("ok"))
+    resp = http.safe_get("https://anywhere.test/path")
+    assert isinstance(resp, DummyResponse)
+
+
+def test_safe_request_invalid_scheme():
+    with pytest.raises(ValueError):
+        http.safe_get("ftp://example.com/file")
+
+
+def test_env_allowlist(monkeypatch):
+    monkeypatch.setenv("OUTBOUND_ALLOWLIST", "example.com, test.org")
+    monkeypatch.setattr(http.requests, "request", lambda *a, **k: DummyResponse("ok"))
+    resp = http.safe_get("https://test.org/resource")
+    assert isinstance(resp, DummyResponse)
+    with pytest.raises(http.OutboundDomainError):
+        http.safe_get("https://evil.net")


### PR DESCRIPTION
## Outcome
Added a reusable, fail-closed outbound HTTP helper (`safe_request` / `safe_get`) so future connectors only reach domains on the configured allow-list. By default everything is allowed; set `OUTBOUND_ALLOWLIST` (comma-separated) to restrict outbound requests.

## Changes
- `services/api/app/tools/http.py`: new module exposing `safe_request`/`safe_get` plus `OutboundDomainError` and allow-list parsing.
- `services/api/tests/unit/test_http.py`: coverage for exact domains, subdomains, env-driven allow-list, blocking behavior, and invalid schemes.
- Updated `docs/config.md` and `.env.example` documenting `OUTBOUND_ALLOWLIST`.
- Makefile untouched apart from previous tasks (no extra CI wiring needed yet).

## Testing
- `venv/bin/pytest` (unit + integration)
- `venv/bin/pytest services/api/tests/unit/test_http.py -q`

## Notes
- Allow-list entries match the domain and any subdomain (e.g., `example.com` permits `api.example.com`).
- Helper raises `OutboundDomainError` when a URL isn’t allowed, before making any network call.
- Future connectors can import `safe_get`/`safe_request` to comply with the allow-list automatically.
