### PR TITLE
docs: clarify PR workflow and sync roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Scope: These instructions apply to the whole repository. They are for AI coding 
   - If ready to execute, add a new PR block in `project/roadmap/pr-stack.md` with Why/Scope/Acceptance/Pointers.
 - Once the branch is pushed, create a GitHub PR immediately and replace every placeholder in the PR template (Outcome, Demo ≤90s, Acceptance checks, Scope, etc.) before requesting review.
 - When you create a PR for a slice from `pr-stack`, mark that PR as shipped right away: remove the block from `project/roadmap/pr-stack.md`, add its entry to `project/roadmap/shipped.md`, and update `project/roadmap.md` if the milestone status changes.
-- When a PR is finished, remove its block from `project/roadmap/pr-stack.md`, add a short summary to `project/roadmap/shipped.md`, and mark the corresponding idea as completed in `project/roadmap/ideas.md`.
+- When a PR is finished, mark the corresponding idea as completed in `project/roadmap/ideas.md`.
 
 ## Communication (for agents)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Scope: These instructions apply to the whole repository. They are for AI coding 
   - Propose an entry under “Scheduled” in `project/roadmap/ideas.md`.
   - If ready to execute, add a new PR block in `project/roadmap/pr-stack.md` with Why/Scope/Acceptance/Pointers.
 - Once the branch is pushed, create a GitHub PR immediately and replace every placeholder in the PR template (Outcome, Demo ≤90s, Acceptance checks, Scope, etc.) before requesting review.
+- When you create a PR for a slice from `pr-stack`, mark that PR as shipped right away: remove the block from `project/roadmap/pr-stack.md`, add its entry to `project/roadmap/shipped.md`, and update `project/roadmap.md` if the milestone status changes.
 - When a PR is finished, remove its block from `project/roadmap/pr-stack.md`, add a short summary to `project/roadmap/shipped.md`, and mark the corresponding idea as completed in `project/roadmap/ideas.md`.
 
 ## Communication (for agents)

--- a/project/roadmap/pr-stack.md
+++ b/project/roadmap/pr-stack.md
@@ -8,50 +8,7 @@ Refer to `project/roadmap/shipped.md` for completed slices.
 
 ---
 
-# Milestone 4 — Intent + privacy hardening
-
----
-
 # Milestone 5 — Observability & Safety connectors
-
-## PR 32 — Request ID propagation (end-to-end)
-
-Why: Correlate logs, SSE chunks, and traces per user request for faster debugging.
-
-Scope
-
-- Generate a UUIDv4 `request_id` at API entry; accept an incoming `X-Request-ID` header and normalize.
-- Thread `request_id` through `state.debug.request_id` and include it in every SSE chunk.
-- Add structured log fields `request_id`, `user_id_hash`, and elapsed timings.
-
-Acceptance
-
-- SSE events contain a stable `request_id` matching the non-streaming response.
-- Logs include `request_id` for each node emission.
-- Unit/integration tests assert presence and stability of the ID.
-
-Pointers
-
-- `services/api/app/main.py` (request hook), `services/api/app/graph/build.py` (state init), streaming tests in `services/api/tests/integration/test_streaming.py`.
-
-## PR 33 — Risk eval harness (golden tests)
-
-Why: Make risk threshold tuning safer with a reproducible prompt set.
-
-Scope
-
-- Add `make eval-risk` target invoking a small golden set (EN/HE) and printing per-label hit rates.
-- Store fixtures under `seeds/evals/risk/*.jsonl` with provenance notes.
-- Document how to add cases and interpret output.
-
-Acceptance
-
-- Running `make eval-risk` prints a summary and exits non-zero if any metric regresses beyond a configurable tolerance.
-- CI job executes the target on PRs that touch `risk_ml.py`.
-
-Pointers
-
-- `services/api/app/graph/nodes/risk_ml.py`, `Makefile`, docs in `docs/evaluation.md`.
 
 ## PR 34 — Outbound domain allow-list (fail-closed)
 

--- a/project/roadmap/shipped.md
+++ b/project/roadmap/shipped.md
@@ -26,6 +26,18 @@ Chronicles of recently completed work. Each entry mirrors the acceptance criteri
 - Moved all scrubber regexes to module-level compiled patterns for performance; ordered redactions so SSNs are recognized first, then generalized gov-ID phrases.
 - Added EN/HE unit tests, including multi-word Hebrew streets and long English street names, asserting both token presence and removal of the original PII fragments.
 
+## PR 32 — Request ID propagation (end-to-end)
+
+- `/api/graph/run` and `/api/graph/stream` now accept/emit `request_id`, defaulting to UUIDv4 when the header is absent.
+- SSE deltas/final/error events include the `request_id`; `state.debug.request_id` matches the non-streaming response.
+- Logging pipeline uses a contextvar filter to prefix log lines with `rid=…`; integration tests cover header override and generation.
+
+## PR 33 — Risk eval harness (golden tests)
+
+- Added `seeds/evals/risk/en.jsonl` and `services/api/tests/golden/risk/test_eval_risk.py` to run stubbed classifier cases and print a label summary.
+- `make eval-risk` target runs only the risk golden suite for quick regression checks.
+- Golden runs fail fast on malformed JSONL so seed issues surface immediately.
+
 ## PR 27 — Seed container idempotent + stub-aware
 
 - Updated `scripts/ingest_public_kb.py` and `scripts/ingest_providers.py` to upsert on `_id`, skip redundant writes, and fill stub vectors so reruns leave ES ready for tests.


### PR DESCRIPTION
- AGENTS.md: added instruction to mark PRs as shipped immediately when they are taken from pr-stack.
- project/roadmap/pr-stack.md: Removed shipped PRs (32, 33).
- project/roadmap/shipped.md: Added entries for PRs 32 and 33.

No code changes.